### PR TITLE
fix(ios): added condition if scheme is NSNull

### DIFF
--- a/src/ios/AppAvailability.m
+++ b/src/ios/AppAvailability.m
@@ -9,7 +9,7 @@
     
     NSString* scheme = [command.arguments objectAtIndex:0];
     
-    if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:scheme]]) {
+    if (![scheme isEqual:[NSNull null]] && [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:scheme]]) {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:(true)];
     }
     else {


### PR DESCRIPTION
## Do que se trata essa mudança?

* [ ] - Nova(s) funcionalidade(s)
* [x] - Correção de bug(s)
* [ ] - Documentação
* [ ] - Outros (especificar)

Fix do bug no ipad com o iOS 14.5 

## iOS scheme nsnull error

- Está acontecendo um bug, somente no iPad com iOS 14.5, que passa um valor nulo em vez de uma string. Para contornar esse problema, foi adicionado uma validação para quando a variável **scheme** for igual a NSNull

## Áreas impactadas

* src/ios/AppAvailability.m